### PR TITLE
Reconfigure interface for saving PF cands

### DIFF
--- a/python/addBTV.py
+++ b/python/addBTV.py
@@ -216,10 +216,7 @@ def get_DeepCSV_vars():
     )
     return DeepCSVVars
 
-def add_BTV(process, runOnMC=False, onlyAK4=False, onlyAK8=False, keepInputs=True):
-    addAK4 = not onlyAK8
-    addAK8 = not onlyAK4
-
+def add_BTV(process, runOnMC=False, addAK4=True, addAK8=True, addAK15=False, keepInputs=True):
     if addAK4:
         process = update_jets_AK4(process)
     if addAK8:

--- a/python/pfnano_cff.py
+++ b/python/pfnano_cff.py
@@ -5,61 +5,61 @@ from PhysicsTools.NanoAOD.common_cff import Var
 
 
 def PFnano_customizeMC(process):
-    addPFCands(process, True)
-    add_BTV(process, True)
+    addPFCands(process, runOnMC=True, saveAK4=True, saveAK8=True)
+    add_BTV(process, runOnMC=True)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeMC_allPF(process):
-    addPFCands(process, True, True)
-    add_BTV(process, True)
+    addPFCands(process, runOnMC=True, saveAll=True)
+    add_BTV(process, runOnMC=True)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 
 def PFnano_customizeMC_AK4JetsOnly(process):
-    addPFCands(process, True, False, True)
-    add_BTV(process, True, True)
+    addPFCands(process, runOnMC=True, saveAK4=True)
+    add_BTV(process, runOnMC=True, addAK4=True, addAK8=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeMC_AK8JetsOnly(process):
-    addPFCands(process, True, False, False, True)
-    add_BTV(process, True, False, True)
+    addPFCands(process, runOnMC=True, saveAK8=True)
+    add_BTV(process, runOnMC=True, addAK4=False, addAK8=True)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeMC_noInputs(process):
-    add_BTV(process, True, keepInputs=False)
+    add_BTV(process, runOnMC=True, keepInputs=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 #### DATA customization
 def PFnano_customizeData(process):
-    addPFCands(process, False)
-    add_BTV(process, False)
+    addPFCands(process, runOnMC=False, saveAK4=True, saveAK8=True)
+    add_BTV(process, runOnMC=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeData_allPF(process):
-    addPFCands(process, False, True)
-    add_BTV(process, False)
+    addPFCands(process, runOnMC=False, saveAll=True)
+    add_BTV(process, runOnMC=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeData_AK4JetsOnly(process):
-    addPFCands(process, False, False, True)
-    add_BTV(process, False, True)
+    addPFCands(process, runOnMC=False, saveAK4=True)
+    add_BTV(process, runOnMC=False, addAK4=True, addAK8=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeData_AK8JetsOnly(process):
-    addPFCands(process, False, False, False, True)
-    add_BTV(process, False, False, True)
+    addPFCands(process, runOnMC=False, saveAK4=True)
+    add_BTV(process, runOnMC=False, addAK4=False, addAK8=True)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
 def PFnano_customizeData_noInputs(process):
-    add_BTV(process, False, keepInputs=False)
+    add_BTV(process, runOnMC=False, keepInputs=False)
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process


### PR DESCRIPTION
(I'm not sure this is the best place to talk about AK15 in general, maybe we should discuss this first)

Before trying to add AK15 PF candidates, this PR changes the arguments for `addPFcands()` and `add_BTV()` to specify which collections to save inclusively (`addAK4`, `addAK8`) instead of exclusively (`onlyAK4`, `onlyAK8`). This makes it easier to add another collection (`addAK15`), instead of enumerating the 2^(N jet collections) combinations. 

**Validation**
Recreated all the CMSSW config files with `make_configs_UL.sh`, dumped the full configs with `edmConfigDump`, and confirmed that the configs are identical with `diff`, except for an intended change to the docstring ("from AK4 and AK8 jets" --> "from various jet collections"). 

