### PR TITLE
feat: fine-grained truth flavour AK4 jets, examples to run over Mini v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # PFNano
 
-This is a [NanoAOD](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD) framework for advance developments of jet algorithms. 
-The current full content of this development branch can be seen [here](http://algomez.web.cern.ch/algomez/testWeb/PFnano_content_v02.html) and the size [here](http://algomez.web.cern.ch/algomez/testWeb/PFnano_size_v02.html).
+This is a [NanoAOD](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD) framework for advanced developments of jet algorithms. 
+
+The repository consists of multiple branches which are each dedicated to specific releases of [CMSSW](https://github.com/cms-sw/cmssw). If you came here to run over Run3 samples, please checkout the most up-to-date 12_4_8 branch (e.g. from the dropdown menu above). The master branch you are viewing right now is optimized to run over Run2 samples, using the 106X release cycle.
+
+
+The current full content of this development branch can be seen [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_desc.html) and the size [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_size.html).
 In this version, PFcandidates can be saved for AK4 only, AK8 only, or all the PF candidates. More below.
 This format can be used with [fastjet](http://fastjet.fr) directly.
 
@@ -24,15 +28,7 @@ Note: When running over a new dataset you should check with [the nanoAOD workboo
 
 ## Local Usage:
 
-There are python config files ready to run in `PhysicsTools/PFNano/test/` for the UL campaign of nanoAODv8, named `nano106Xv8_on_mini106X_201*_data_NANO.py`. Notice that the current version can create 4 types of files depending on the PF candidates content. 
-In this files, for simplicity, the 4 options are included but only one is commented out for use. For instance:
-```
-process = PFnano_customizeMC(process)
-#process = PFnano_customizeMC_allPF(process)            ##### PFcands will content ALL the PF Cands
-#process = PFnano_customizeMC_AK4JetsOnly(process)      ##### PFcands will content only the AK4 jets PF cands
-#process = PFnano_customizeMC_AK8JetsOnly(process)      ##### PFcands will content only the AK8 jets PF cands
-#process = PFnano_customizeMC_noInputs(process)         ##### No PFcands but all the other content is available.
-```
+There are python config files ready to run in `PhysicsTools/PFNano/test/` for the UL campaign of nanoAODv8, named `nano106Xv8_on_mini106X_201*_data_NANO.py`. Notice that the current version can create different types of files depending on the PF candidates content.
 
 New since Pull Request [#39](https://github.com/cms-jet/PFNano/pull/39): Examples to include or exclude the input features for the DeepJet tagger are given in `nano106Xv8_on_mini106X_2017_mc_NANO.py`. Now the list of options that are currently implemented inside `pfnano_cff.py` (e.g. for MC) looks like that:
 ```
@@ -45,7 +41,9 @@ process = PFnano_customizeMC(process)
 #process = PFnano_customizeMC_AK8JetsOnly(process)                  ##### PFcands will content only the AK8 jets PF cands
 #process = PFnano_customizeMC_noInputs(process)                     ##### No PFcands but all the other content is available.
 ```
-In general, whenever `_add_DeepJet` is specified (does not apply to `AK8JetsOnly` and `noInputs`), the DeepJet inputs are added to the Jet collection. For all other cases that involve adding tagger inputs, only DeepCSV and / or DDX are taken into account as default (= the old behaviour when `keepInputs=True`). Internally, this is handled by selecting a list of taggers, namely choosing from `DeepCSV`, `DeepJet`, and `DDX` (or an empty list for the `noInputs`-case, formerly done by setting `keepInputs=False`, now set `keepInputs=[]`). This refers to a change of the logic inside `pfnano_cff.py` and `addBTV.py`. If one wants to use this new flexibility, one can also define new customization functions with other combinations of taggers. Currently, there are all configurations to reproduce the ones that were available previously, and all configuations that extend the old ones by adding DeepJet inputs. DeepJet outputs, on top of the discriminators already present in NanoAOD, are added in any case where AK4Jets are added, i.e. there is no need to require the full set of inputs to get the individual output nodes / probabilities. The updated description using `PFnano_customizeMC_add_DeepJet` can be viewed here: [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_desc.html) and the size [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_size.html).
+In general, whenever `_add_DeepJet` is specified (does not apply to `AK8JetsOnly` and `noInputs`), the DeepJet inputs are added to the Jet collection. For all other cases that involve adding tagger inputs, only DeepCSV and / or DDX are taken into account as default (= the old behaviour when `keepInputs=True`). Internally, this is handled by selecting a list of taggers, namely choosing from `DeepCSV`, `DeepJet`, and `DDX` (or an empty list for the `noInputs`-case, formerly done by setting `keepInputs=False`, now set `keepInputs=[]`). This refers to a change of the logic inside `pfnano_cff.py` and `addBTV.py`. If one wants to use this new flexibility, one can also define new customization functions with other combinations of taggers. Currently, there are all configurations to reproduce the ones that were available previously, and all configuations that extend the old ones by adding DeepJet inputs. DeepJet outputs, on top of the discriminators already present in NanoAOD, are added in any case where AK4Jets are added, i.e. there is no need to require the full set of inputs to get the individual output nodes / probabilities. The updated description using `PFnano_customizeMC_add_DeepJet` can be viewed [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_desc.html) and the size [here](https://annika-stein.web.cern.ch/PFNano/AddDeepJetTagInfo_size.html).
+
+The latest addition before moving to the Run3 recipe was the inclusion of a fine-grained truth flavour branch, which encodes various bits known from DeepNTuples into one integer. It can be activated for simulated samples by adding the `_and_Truth` flag to the customizer, i.e. using `PFnano_customizeMC_add_DeepJet_and_Truth`.
 
 ### How to create python files using cmsDriver
 
@@ -83,6 +81,35 @@ submission yaml card `card_example.yml` are provided.
 - `--make` and `--submit` calls are independent, allowing manual inspection of submit configs
 - Add `--test` to disable publication on otherwise publishable config and produce a single file per dataset
 
+<details>
+    <summary>If experiencing problems with crab submission using the above instructions, e.g. on NAF-DESY</summary>
+    
+    
+    ```
+    source /cvmfs/grid.cern.ch/centos7-umd4-ui-4_200423/etc/profile.d/setup-c7-ui-example.sh
+    source /cvmfs/cms.cern.ch/common/crab-setup.sh prod
+    source /cvmfs/cms.cern.ch/cmsset_default.sh
+    < navigate to CMSSW_X_Y_Z/src >
+    cmsenv
+    cd PhysicsTools/PFNano/test
+    ```
+    
+    
+    and proceed with `crabby.py` as explained above, activate proxy for submission to be successful.
+</details>
+
+<details>
+    <summary>Useful commands to get paths to individual processed files</summary>
+    
+    ```
+    xrdfs [insert redirector to site] ls /store/path/to/your/crab/output/serialnumber > filelist.txt
+    ( if there is more than one serial number (more than 1k files processed) repeat command but append to textfile using >> instead of > )
+    ( clean textfile for log entries )
+    ( then append the redirector (needs modification by you for specific site) using this helper )
+    python dataset_paths.py name_of_txt_file T2_DE_RWTH
+    ```
+    
+</details>
 
 <details>
   <summary>Deprecated submission.</summary>

--- a/interface/helpers.h
+++ b/interface/helpers.h
@@ -1,0 +1,7 @@
+int jet_flavour(const pat::Jet& jet,
+        const std::vector<reco::GenParticle>& gToBB,
+        const std::vector<reco::GenParticle>& gToCC,
+        const std::vector<reco::GenParticle>& neutrinosLepB,
+        const std::vector<reco::GenParticle>& neutrinosLepB_C,
+        const std::vector<reco::GenParticle>& alltaus,
+        bool usePhysForLightAndUndefined);

--- a/python/pfnano_cff.py
+++ b/python/pfnano_cff.py
@@ -16,6 +16,12 @@ def PFnano_customizeMC_add_DeepJet(process):
     process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
     return process
 
+def PFnano_customizeMC_add_DeepJet_and_Truth(process):
+    addPFCands(process, True)
+    add_BTV(process, True, keepInputs=['DeepCSV','DeepJet','DDX'], storeAK4Truth="yes")
+    process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
+    return process
+
 def PFnano_customizeMC_allPF(process):
     addPFCands(process, True, True)
     add_BTV(process, True, keepInputs=['DeepCSV','DDX'])

--- a/test/card_mc_ULv2.yml
+++ b/test/card_mc_ULv2.yml
@@ -1,0 +1,22 @@
+campaign:
+  name: 'test'  # irrelevant
+  crab_template: template_crab.py
+
+  # User specific
+  workArea: mc_ULv2_yml
+  storageSite: T2_DE_RWTH
+  outLFNDirBase: /store/user/anstein/PFNano
+  voGroup: dcms
+
+  # Campaign specific
+  tag_extension: PFtestNano # Will get appended after the current tag
+  tag_mod: # Will modify name in-place for MC eg. "PFNanoAODv1" will replace MiniAODv2 -> PFNanoAODv1
+  publication: True
+  config: nano_mc_2017_ULv2_NANO.py
+  # Specify if running on data
+  # data: True
+  data: False
+  lumiMask:  # json file
+  # datasets will take either a list of DAS names or a text file containing them
+  datasets: /TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM
+  

--- a/test/crabby.py
+++ b/test/crabby.py
@@ -126,15 +126,18 @@ if args.make:
 if args.submit:
     from multiprocessing import Process
     import imp
-    print("Submitting configs:")
-    for dataset in datasets:
-        print("   ==> "+dataset)
-        dataset_name = dataset.lstrip("/").replace("/", "_")
-        cfg_filename = os.path.join(card['campaign']['workArea'] , 'submit_{}.py'.format(dataset_name))
-        config_file = imp.load_source('config', cfg_filename)
-        p = Process(target=submit, args=(config_file.config,))
-        p.start()
-        p.join()
+    print("Submitting configs.")
+    print("These are the datasets:")
+    print(datasets)
+    if raw_input("Continue? (y/n)") == "y":
+        for dataset in datasets:
+            print("   ==> "+dataset)
+            dataset_name = dataset.lstrip("/").replace("/", "_")
+            cfg_filename = os.path.join(card['campaign']['workArea'] , 'submit_{}.py'.format(dataset_name))
+            config_file = imp.load_source('config', cfg_filename)
+            p = Process(target=submit, args=(config_file.config,))
+            p.start()
+            p.join()
 
 if args.status:
     das_names = []

--- a/test/dataset_paths.py
+++ b/test/dataset_paths.py
@@ -1,0 +1,23 @@
+import os,sys
+# use like that:
+# python dataset_paths.py name_of_txt_file T2_DE_RWTH
+
+site_redirector = {
+    'T2_DE_RWTH' : 'root://grid-cms-xrootd.physik.rwth-aachen.de:1094/',
+    'T2_DE_DESY' : 'root://dcache-cms-xrootd.desy.de:1094/'
+}
+
+txt_name = "doublemuon2017"
+site = "T2_DE_RWTW"
+
+if len(sys.argv) > 1:
+    txt_name = sys.argv[1]
+if len(sys.argv) > 2:
+    site = sys.argv[2]
+    
+fIN = open("%s.txt" % (txt_name),'r')
+fOUT = open("%sURL.txt" % (txt_name),'w')
+for i,line in enumerate(fIN):
+    fOUT.write(site_redirector[site]+line)
+fOUT.close()
+fIN.close()

--- a/test/nano_mc_2017_ULv2_NANO.py
+++ b/test/nano_mc_2017_ULv2_NANO.py
@@ -1,0 +1,102 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: nano_mc_2017_ULv2 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --step NANO --conditions 106X_mc2017_realistic_v9 --era Run2_2017,run2_nanoAOD_106Xv1 --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=100 --nThreads 4 -n -1 --filein /store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/00000/00623789-C012-474B-8860-3C18397A464F.root --fileout file:nano_mc2017_ULv2.root --customise PhysicsTools/PFNano/pfnano_cff.PFnano_customizeMC_add_DeepJet_and_Truth --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+
+process = cms.Process('NANO',Run2_2017,run2_nanoAOD_106Xv1)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('PhysicsTools.NanoAOD.nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/00000/00623789-C012-474B-8860-3C18397A464F.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('nano_mc_2017_ULv2 nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:nano_mc2017_ULv2.root'),
+    outputCommands = process.NANOAODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mc2017_realistic_v9', '')
+
+# Path and EndPath definitions
+process.nanoAOD_step = cms.Path(process.nanoSequenceMC)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODSIMoutput_step = cms.EndPath(process.NANOAODSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step,process.NANOAODSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(4)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.NanoAOD.nano_cff
+from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeMC 
+
+#call to customisation function nanoAOD_customizeMC imported from PhysicsTools.NanoAOD.nano_cff
+process = nanoAOD_customizeMC(process)
+
+# Automatic addition of the customisation function from PhysicsTools.PFNano.pfnano_cff
+from PhysicsTools.PFNano.pfnano_cff import PFnano_customizeMC_add_DeepJet_and_Truth 
+
+#call to customisation function PFnano_customizeMC_add_DeepJet_and_Truth imported from PhysicsTools.PFNano.pfnano_cff
+process = PFnano_customizeMC_add_DeepJet_and_Truth(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=100
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
Backport of #41 #42 #43 but for Run2 recipe.

* fine-grained truth flavour for AK4 jets via GenParticles
* DeepJetTableProducer: access number of jets only once per event
* examples with MiniAODv2
* reduce duplicate branches
* remove unwanted branches (no truth info for data)
* document changes in README and point user to different branches for different campaigns

Just like the 12_4_8 branch solves #27 and #35 for Run3, a similar approach is followed here for Run2 (106X).

Fixes #27
Fixes #35